### PR TITLE
fix: remove nested declare

### DIFF
--- a/iso-8859-2.d.ts
+++ b/iso-8859-2.d.ts
@@ -6,11 +6,11 @@ declare module 'iso-8859-2' {
     mode: 'fatal' | 'replacement';
   };
 
-  export declare function encode(
+  export function encode(
     text: string,
     options?: EncodeOptions
   ): Uint16Array;
-  export declare function decode(
+  export function decode(
     buffer: Uint16Array | Uint8Array | Buffer | string,
     options?: DecodeOptions
   ): string;

--- a/src/iso-8859-2.d.ts
+++ b/src/iso-8859-2.d.ts
@@ -6,11 +6,11 @@ declare module 'iso-8859-2' {
     mode: 'fatal' | 'replacement';
   };
 
-  export declare function encode(
+  export function encode(
     text: string,
     options?: EncodeOptions
   ): Uint16Array;
-  export declare function decode(
+  export function decode(
     buffer: Uint16Array | Uint8Array | Buffer | string,
     options?: DecodeOptions
   ): string;


### PR DESCRIPTION
This nested declare makes the npx tsc fail with the next error:

```
node_modules/iso-8859-2/iso-8859-2.d.ts:9:10 - error TS1038: A 'declare' modifier cannot be used in an already ambient context.

9   export declare function encode(
           ~~~~~~~
```

I'm sending you @mathiasbynens  the following changes in the PR that will fix this error . 